### PR TITLE
experimental type safe eZtreme

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,8 @@ lazy val core = project
   .settings(
     name := "zio-kafka-streams",
     libraryDependencies ++= Seq(
-      "dev.zio" %% "zio" % V.zio
+      "dev.zio" %% "zio"         % V.zio,
+      "dev.zio" %% "zio-prelude" % "latest.integration"
     )
   )
 
@@ -84,7 +85,7 @@ lazy val datagen = project
 
 lazy val examples = project
   .in(file("examples"))
-  .dependsOn(core, datagen)
+  .dependsOn(core, datagen, testkit)
   .settings(commonSettings)
   .settings(
     name := "examples",

--- a/examples/src/main/scala/io/laserdisc/kafka/DangerousGDPR1.scala
+++ b/examples/src/main/scala/io/laserdisc/kafka/DangerousGDPR1.scala
@@ -1,0 +1,56 @@
+package io.laserdisc.kafka
+
+import org.apache.kafka.streams.scala.ImplicitConversions._
+import org.apache.kafka.streams.scala.Serdes._
+import org.apache.kafka.streams.scala.StreamsBuilder
+import org.apache.kafka.streams.scala.kstream._
+import org.apache.kafka.streams.{ StreamsConfig, Topology }
+import zio.UIO
+import zio.kafka.streams.KafkaStreamsTopology
+import zio.kafka.streams.testkit.ZTestTopology
+import zio.test.Assertion.equalTo
+import zio.test._
+import zio.test.environment.TestEnvironment
+
+import java.util.Properties
+
+object DangerousGDPR1 {
+  val config: Properties = {
+    val jProperties = new Properties()
+    jProperties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+    jProperties
+  }
+
+  val builder: StreamsBuilder           = new StreamsBuilder()
+  val newUsers: KStream[String, String] = builder.stream[String, String]("new-users-input")
+  val branches: Array[KStream[String, String]] =
+    newUsers.branch((k, _) => k.startsWith("u"), (k, _) => k.startsWith("p"))
+  // array is 0 based
+  val USERNAME = 1
+  val PASSWORD = 2
+  branches(USERNAME).to("new-users-output")
+
+  val topology: Topology = builder.build()
+}
+
+object DangerousGDPR1Spec extends DefaultRunnableSpec {
+  private[this] val testLayer =
+    ZTestTopology.testConfigLayer(true) >+> KafkaStreamsTopology.make(UIO(DangerousGDPR1.topology))
+
+  override def spec: ZSpec[TestEnvironment, Any] =
+    suite("newUsersSpec")(
+      testM("topology") {
+        for {
+          outputValue <- ZTestTopology.driver.use { driver =>
+            for {
+              input  <- driver.createInput[String, String]("new-users-input")
+              output <- driver.createOutput[String, String]("new-users-output")
+              _      <- input.produce("p001", "Giovanni")
+              _      <- input.produce("u001", "password1")
+              value  <- output.consumeValue
+            } yield value
+          }
+        } yield assert(outputValue)(equalTo("Giovanni"))
+      }.provideSomeLayerShared(testLayer.mapError(TestFailure.fail))
+    )
+}

--- a/examples/src/main/scala/io/laserdisc/kafka/DangerousGDPR2.scala
+++ b/examples/src/main/scala/io/laserdisc/kafka/DangerousGDPR2.scala
@@ -1,0 +1,61 @@
+package io.laserdisc.kafka
+
+import org.apache.kafka.streams.scala.ImplicitConversions._
+import org.apache.kafka.streams.scala.Serdes._
+import org.apache.kafka.streams.scala.StreamsBuilder
+import org.apache.kafka.streams.scala.kstream._
+import org.apache.kafka.streams.{ StreamsConfig, Topology }
+import zio.UIO
+import zio.kafka.streams.KafkaStreamsTopology
+import zio.kafka.streams.testkit.ZTestTopology
+import zio.test.Assertion.equalTo
+import zio.test._
+import zio.test.environment.TestEnvironment
+
+import java.util.Properties
+
+object DangerousGDPR2 {
+  val config: Properties = {
+    val jProperties = new Properties()
+    jProperties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+    jProperties
+  }
+
+  val builder: StreamsBuilder           = new StreamsBuilder()
+  val newUsers: KStream[String, String] = builder.stream[String, String]("new-users-input")
+  val branches: Array[KStream[String, String]] =
+    newUsers.branch((k, _) => k.startsWith("u"), (k, _) => k.startsWith("c"))
+  val USERNAME                                            = 0
+  def securelyMappingUserForOutput(user: String): String  = identity(user)
+  val CREDIT_CARD                                         = 1
+  def securelyMappingCardForOutput(ccard: String): String = "************" + ccard.substring(12)
+  val processUser: KStream[String, String] =
+    branches(USERNAME).mapValues(username => securelyMappingUserForOutput(username))
+  val maskedCC: KStream[String, String] =
+    branches(CREDIT_CARD).mapValues(creditCard => securelyMappingUserForOutput(creditCard))
+  maskedCC.to("new-users-output")
+
+  val topology: Topology = builder.build()
+}
+
+object DangerousGDPR2Spec extends DefaultRunnableSpec {
+  private[this] val testLayer =
+    ZTestTopology.testConfigLayer(true) >+> KafkaStreamsTopology.make(UIO(DangerousGDPR2.topology))
+
+  override def spec: ZSpec[TestEnvironment, Any] =
+    suite("newUsersSpec")(
+      testM("topology") {
+        for {
+          outputValue <- ZTestTopology.driver.use { driver =>
+            for {
+              input  <- driver.createInput[String, String]("new-users-input")
+              output <- driver.createOutput[String, String]("new-users-output")
+              _      <- input.produce("u001", "Giovanni")
+              _      <- input.produce("c001", "5483987343872038")
+              value  <- output.consumeValue
+            } yield value
+          }
+        } yield assert(outputValue)(equalTo("************2038"))
+      }.provideSomeLayerShared(testLayer.mapError(TestFailure.fail))
+    )
+}

--- a/examples/src/main/scala/io/laserdisc/kafka/SafeGDPR1.scala
+++ b/examples/src/main/scala/io/laserdisc/kafka/SafeGDPR1.scala
@@ -1,0 +1,58 @@
+package io.laserdisc.kafka
+
+import org.apache.kafka.streams.scala.{ Serdes, StreamsBuilder }
+import org.apache.kafka.streams.{ StreamsConfig, Topology }
+import zio.UIO
+import zio.kafka.streams.testkit.ZTestTopology
+import zio.kafka.streams.{ KafkaStreamsTopology, SafeTopic, TopologySdk }
+import zio.prelude.State
+import zio.test.Assertion.equalTo
+import zio.test.environment.TestEnvironment
+import zio.test.{ DefaultRunnableSpec, TestFailure, ZSpec, suite, testM, _ }
+
+import java.util.Properties
+
+object SafeGDPR1 extends TopologySdk {
+  val config: Properties = {
+    val jProperties = new Properties()
+    jProperties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+    jProperties
+  }
+
+  val passwordFilter: (String, String) => Boolean = (k, _) => k.startsWith("p")
+  val usernameFilter: (String, String) => Boolean = (k, _) => k.startsWith("u")
+
+  val newUsersIn: SafeTopic[String, String]  = SafeTopic("new-users-input", Serdes.String, Serdes.String)
+  val newUsersOut: SafeTopic[String, String] = SafeTopic("new-users-output", Serdes.String, Serdes.String)
+
+  val topologyReader: State[StreamsBuilder, Topology] = for {
+    input    <- streamFromSource(newUsersIn)
+    branches <- branch(input)(usernameFilter, passwordFilter)
+    _        <- streamSinkTo(branches(passwordFilter), newUsersOut)
+    topology <- toTopology
+  } yield topology
+
+  val topology: Topology = topologyReader.runResult(new StreamsBuilder())
+}
+
+object SafeGDPR1Spec extends DefaultRunnableSpec {
+  private[this] val testLayer =
+    ZTestTopology.testConfigLayer(true) >+> KafkaStreamsTopology.make(UIO(SafeGDPR1.topology))
+
+  override def spec: ZSpec[TestEnvironment, Any] =
+    suite("newUsersSpec")(
+      testM("topology") {
+        for {
+          outputValue <- ZTestTopology.driver.use { driver =>
+            for {
+              input  <- driver.createInput[String, String]("new-users-input")
+              output <- driver.createOutput[String, String]("new-users-output")
+              _      <- input.produce("u001", "Giovanni")
+              _      <- input.produce("p001", "password1")
+              value  <- output.consumeValue
+            } yield value
+          }
+        } yield assert(outputValue)(equalTo("Giovanni"))
+      }.provideSomeLayerShared(testLayer.mapError(TestFailure.fail))
+    )
+}

--- a/examples/src/main/scala/io/laserdisc/kafka/SaferGDPR1.scala
+++ b/examples/src/main/scala/io/laserdisc/kafka/SaferGDPR1.scala
@@ -1,0 +1,74 @@
+package io.laserdisc.kafka
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.scala.{ Serdes, StreamsBuilder }
+import org.apache.kafka.streams.{ StreamsConfig, Topology }
+import zio.UIO
+import zio.kafka.streams.testkit.ZTestTopology
+import zio.kafka.streams.{ KafkaStreamsTopology, SafeTopic, TopologySdk }
+import zio.prelude.State
+import zio.test.Assertion.equalTo
+import zio.test.environment.TestEnvironment
+import zio.test.{ DefaultRunnableSpec, TestFailure, ZSpec, suite, testM, _ }
+
+import java.util.Properties
+import zio.prelude.Subtype
+import zio.kafka.streams.Extractor
+
+object SaferGDPR1 extends TopologySdk {
+  object Username extends Subtype[String]
+  type Username = Username.Type
+  object Password extends Subtype[String]
+  type Password = Password.Type
+
+  val config: Properties = {
+    val jProperties = new Properties()
+    jProperties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+    jProperties
+  }
+
+  val passwordFilter: (String, String) => Boolean = (k, _) => k.startsWith("p")
+  val passwordExtractor: Extractor[String, String, Password] =
+    Extractor(passwordFilter)(_.asInstanceOf[Password])
+  val passwordSerde: Serde[Password]              = Serdes.String.asInstanceOf[Serde[Password]]
+  val usernameFilter: (String, String) => Boolean = (k, _) => k.startsWith("u")
+  val usernameExtractor: Extractor[String, String, Username] =
+    Extractor(usernameFilter)(_.asInstanceOf[Username])
+  val usernameSerde: Serde[Username] = Serdes.String.asInstanceOf[Serde[Username]]
+
+  val newUsersIn: SafeTopic[String, String]    = SafeTopic("new-users-input", Serdes.String, Serdes.String)
+  val newUsersOut: SafeTopic[String, Username] = SafeTopic("new-users-output", Serdes.String, usernameSerde)
+
+  val topologyReader: State[StreamsBuilder, Topology] = for {
+    input    <- streamFromSource(newUsersIn)
+    branches <- safeBranch(input)(usernameExtractor, passwordExtractor)
+    (usernames, passwords) = branches // cannot inline this due to missing `withFilter` in ZPure
+    // ^-- try and switch these
+    _        <- streamSinkTo(usernames, newUsersOut)
+    topology <- toTopology
+  } yield topology
+
+  val topology: Topology = topologyReader.runResult(new StreamsBuilder())
+}
+
+object SaferGDPR1Spec extends DefaultRunnableSpec {
+  private[this] val testLayer =
+    ZTestTopology.testConfigLayer(true) >+> KafkaStreamsTopology.make(UIO(SaferGDPR1.topology))
+
+  override def spec: ZSpec[TestEnvironment, Any] =
+    suite("newUsersSpec")(
+      testM("topology") {
+        for {
+          outputValue <- ZTestTopology.driver.use { driver =>
+            for {
+              input  <- driver.createInput[String, String]("new-users-input")
+              output <- driver.createOutput[String, String]("new-users-output")
+              _      <- input.produce("u001", "Giovanni")
+              _      <- input.produce("p001", "password1")
+              value  <- output.consumeValue
+            } yield value
+          }
+        } yield assert(outputValue)(equalTo("Giovanni"))
+      }.provideSomeLayerShared(testLayer.mapError(TestFailure.fail))
+    )
+}

--- a/examples/src/main/scala/io/laserdisc/kafka/SaferGDPR2.scala
+++ b/examples/src/main/scala/io/laserdisc/kafka/SaferGDPR2.scala
@@ -1,0 +1,85 @@
+package io.laserdisc.kafka
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.scala.{ Serdes, StreamsBuilder }
+import org.apache.kafka.streams.{ StreamsConfig, Topology }
+import zio.UIO
+import zio.kafka.streams.testkit.ZTestTopology
+import zio.kafka.streams.{ KafkaStreamsTopology, SafeTopic, TopologySdk }
+import zio.prelude.State
+import zio.test.Assertion.equalTo
+import zio.test.environment.TestEnvironment
+import zio.test.{ DefaultRunnableSpec, TestFailure, ZSpec, suite, testM, _ }
+
+import java.util.Properties
+import zio.prelude.Subtype
+import zio.kafka.streams.Extractor
+
+object SaferGDPR2 extends TopologySdk {
+  object Username extends Subtype[String]
+  type Username = Username.Type
+  object Password extends Subtype[String]
+  type Password = Password.Type
+  object CreditCard extends Subtype[String]
+  type CreditCard = CreditCard.Type
+
+  val config: Properties = {
+    val jProperties = new Properties()
+    jProperties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+    jProperties
+  }
+
+  def securelyMappingUserForOutput(user: Username): Username  = identity(user)
+  def securelyMappingCardForOutput(ccard: CreditCard): String = "************" + ccard.substring(12)
+
+  val passwordFilter: (String, String) => Boolean = (k, _) => k.startsWith("p")
+  val passwordExtractor: Extractor[String, String, Password] =
+    Extractor(passwordFilter)(_.asInstanceOf[Password])
+  val passwordSerde: Serde[Password]                = Serdes.String.asInstanceOf[Serde[Password]]
+  val creditCardFilter: (String, String) => Boolean = (k, _) => k.startsWith("c")
+  val creditCardExtractor: Extractor[String, String, CreditCard] =
+    Extractor(creditCardFilter)(_.asInstanceOf[CreditCard])
+  val creditCardSerde: Serde[CreditCard]          = Serdes.String.asInstanceOf[Serde[CreditCard]]
+  val usernameFilter: (String, String) => Boolean = (k, _) => k.startsWith("u")
+  val usernameExtractor: Extractor[String, String, Username] =
+    Extractor(usernameFilter)(_.asInstanceOf[Username])
+  val usernameSerde: Serde[Username] = Serdes.String.asInstanceOf[Serde[Username]]
+
+  val newUsersIn: SafeTopic[String, String]  = SafeTopic("new-users-input", Serdes.String, Serdes.String)
+  val newUsersOut: SafeTopic[String, String] = SafeTopic("new-users-output", Serdes.String, Serdes.String)
+
+  val topologyReader: State[StreamsBuilder, Topology] = for {
+    input    <- streamFromSource(newUsersIn)
+    branches <- safeBranch(input)(usernameExtractor, creditCardExtractor)
+    (usernames, creditCards) = branches // cannot inline this due to missing `withFilter` in ZPure
+    maskedCreditCards <- streamMapValues(creditCards)(
+      securelyMappingCardForOutput // try putting the user one
+    )
+    _        <- streamSinkTo(maskedCreditCards, newUsersOut)
+    topology <- toTopology
+  } yield topology
+
+  val topology: Topology = topologyReader.runResult(new StreamsBuilder())
+}
+
+object SaferGDPR2Spec extends DefaultRunnableSpec {
+  private[this] val testLayer =
+    ZTestTopology.testConfigLayer(true) >+> KafkaStreamsTopology.make(UIO(SaferGDPR2.topology))
+
+  override def spec: ZSpec[TestEnvironment, Any] =
+    suite("newUsersSpec")(
+      testM("topology") {
+        for {
+          outputValue <- ZTestTopology.driver.use { driver =>
+            for {
+              input  <- driver.createInput[String, String]("new-users-input")
+              output <- driver.createOutput[String, String]("new-users-output")
+              _      <- input.produce("u001", "Giovanni")
+              _      <- input.produce("c001", "5483987343872038")
+              value  <- output.consumeValue
+            } yield value
+          }
+        } yield assert(outputValue)(equalTo("************2038"))
+      }.provideSomeLayerShared(testLayer.mapError(TestFailure.fail))
+    )
+}

--- a/modules/core/src/main/scala/zio/kafka/streams/TopologySdk.scala
+++ b/modules/core/src/main/scala/zio/kafka/streams/TopologySdk.scala
@@ -1,0 +1,69 @@
+package zio.kafka.streams
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.Topology
+import org.apache.kafka.streams.scala.StreamsBuilder
+import org.apache.kafka.streams.scala.kstream.{ Consumed, KStream, Produced }
+import zio.prelude.State
+import zio.prelude.fx.ZPure
+
+trait TopologySdk {
+  def streamFromSource[K, V](
+    sourceSafeTopic: SafeTopic[K, V]
+  ): State[StreamsBuilder, KStream[K, V]] = {
+    val consumed = Consumed.`with`(sourceSafeTopic.keySerde, sourceSafeTopic.valueSerde)
+    ZPure
+      .get[StreamsBuilder]
+      .map(_.stream[K, V](sourceSafeTopic.topicName)(consumed))
+  }
+
+  def streamSinkTo[K, V](
+    stream: KStream[K, V],
+    sinkSafeTopic: SafeTopic[K, V]
+  ): ZPure[StreamsBuilder, StreamsBuilder, Any, Nothing, Unit] = {
+    val produced = Produced.`with`(sinkSafeTopic.keySerde, sinkSafeTopic.valueSerde)
+    ZPure
+      .unit[StreamsBuilder]
+      .as(stream.to(sinkSafeTopic.topicName)(produced))
+  }
+
+  def branch[K, V](stream: KStream[K, V])(
+    predicate1: (K, V) => Boolean,
+    predicate2: (K, V) => Boolean
+  ): State[StreamsBuilder, Map[(K, V) => Boolean, KStream[K, V]]] =
+    ZPure.unit[StreamsBuilder].as {
+      val branches = stream.branch(predicate1, predicate2)
+      Map(
+        predicate1 -> branches(0),
+        predicate2 -> branches(1)
+      )
+    }
+
+  def safeBranch[K, Vin, Vout1 <: Vin, Vout2 <: Vin](stream: KStream[K, Vin])(
+    extractor1: Extractor[K, Vin, Vout1],
+    extractor2: Extractor[K, Vin, Vout2]
+  ): State[StreamsBuilder, (KStream[K, Vout1], KStream[K, Vout2])] =
+    ZPure.unit[StreamsBuilder].as {
+      val branches = stream.branch(extractor1.predicate, extractor2.predicate)
+      val stream1  = branches(0).mapValues(extractor1.downcaster)
+      val stream2  = branches(1).mapValues(extractor2.downcaster)
+      (stream1, stream2)
+    }
+
+  def streamMapValues[K, Vin, Vout](stream: KStream[K, Vin])(
+    f: Vin => Vout
+  ): State[StreamsBuilder, KStream[K, Vout]] =
+    ZPure.unit[StreamsBuilder].as(stream.mapValues(f))
+
+  def toTopology: State[StreamsBuilder, Topology] = ZPure.get.map(_.build())
+}
+
+final case class SafeTopic[K, V](topicName: String, keySerde: Serde[K], valueSerde: Serde[V])
+final class Extractor[K, Vin, Vout <: Vin] private (
+  val predicate: (K, Vin) => Boolean,
+  val downcaster: Vin => Vout
+)
+object Extractor {
+  def apply[K, Vin, Vout <: Vin](predicate: (K, Vin) => Boolean)(downcaster: Vin => Vout) =
+    new Extractor[K, Vin, Vout](predicate, downcaster)
+}


### PR DESCRIPTION
This is a seminal version to set a target state for this library
cc: @niqdev 
There are 5 example files. The first 2 are plain kafka to show the downsides of not being typesafe, they compile but the  test fails. The third `SafeGDPR1` is a compromise it makes harder to mix up variables. The target state is represented by the `Safer` version, the last 2 files, it makes it impossible to mix up variables because it doesn't compile otherwise.

After you review these files we can start planning what is the preferred target state and how to migrate your API to make it compatible.